### PR TITLE
chore: Add unit test on complex type

### DIFF
--- a/examples/webdriver/local.ts
+++ b/examples/webdriver/local.ts
@@ -586,7 +586,7 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string;
 export type ScriptInternalId = string;
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue;
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue;
 export type ScriptListLocalValue = ScriptLocalValue[];
 
 export interface ScriptArrayLocalValue {

--- a/examples/webdriver/remote.ts
+++ b/examples/webdriver/remote.ts
@@ -919,7 +919,7 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string;
 export type ScriptInternalId = string;
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue;
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue;
 export type ScriptListLocalValue = ScriptLocalValue[];
 
 export interface ScriptArrayLocalValue {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "camelcase": "^9.0.0",
-        "cddl": "^0.13.0",
+        "cddl": "^0.13.1",
         "recast": "^0.23.11",
         "yargs": "^18.0.0"
       },
@@ -1467,9 +1467,9 @@
       }
     },
     "node_modules/cddl": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/cddl/-/cddl-0.13.0.tgz",
-      "integrity": "sha512-Rx3eoFU6xoJY3ha4pMsvbtYuB5f3+h9a41QraQ5pNw0WvyNsNKKfZGtoSXIK2qw8W7OwX/QcwTQnkCA9J8h5yg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/cddl/-/cddl-0.13.1.tgz",
+      "integrity": "sha512-DTCnazZVHkIDlXvtgiz+rw/vaeWmSvO6HIccmYJmi7lMTx4J3jC0ook7lBd5mhTcrW1IbyuUT1366kGUbgGuyg==",
       "license": "MIT",
       "dependencies": {
         "yargs": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@babel/parser": "^7.29.0",
     "camelcase": "^9.0.0",
-    "cddl": "^0.13.0",
+    "cddl": "^0.13.1",
     "recast": "^0.23.11",
     "yargs": "^18.0.0"
   }

--- a/tests/__fixtures__/complex_types.cddl
+++ b/tests/__fixtures__/complex_types.cddl
@@ -1,0 +1,43 @@
+
+LocalValue = (
+  ArrayLocalValue /
+  { DateLocalValue } /
+  MapLocalValue /
+  ObjectLocalValue /
+  { RegExpLocalValue } /
+  SetLocalValue
+)
+
+ArrayLocalValue = {
+  type: "array",
+  value: ListLocalValue,
+}
+
+DateLocalValue = (
+  type: "date",
+  value: text
+)
+
+MapLocalValue = {
+  type: "map",
+  value: MappingLocalValue,
+}
+
+ObjectLocalValue = {
+  type: "object",
+  value: MappingLocalValue,
+}
+
+RegExpLocalValue = (
+  type: "regexp",
+  value: text
+)
+
+SetLocalValue = {
+  type: "set",
+  value: ListLocalValue,
+}
+
+MappingLocalValue = [*[(LocalValue / text), LocalValue]];
+
+ListLocalValue = [*LocalValue];

--- a/tests/__snapshots__/webdriver_local.test.ts.snap
+++ b/tests/__snapshots__/webdriver_local.test.ts.snap
@@ -589,7 +589,7 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string;
 export type ScriptInternalId = string;
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue;
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue;
 export type ScriptListLocalValue = ScriptLocalValue[];
 
 export interface ScriptArrayLocalValue {

--- a/tests/__snapshots__/webdriver_remote.test.ts.snap
+++ b/tests/__snapshots__/webdriver_remote.test.ts.snap
@@ -922,7 +922,7 @@ export interface ScriptExceptionDetails {
 
 export type ScriptHandle = string;
 export type ScriptInternalId = string;
-export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue;
+export type ScriptLocalValue = ScriptRemoteReference | ScriptPrimitiveProtocolValue | ScriptChannelValue | ScriptArrayLocalValue | ScriptDateLocalValue | ScriptMapLocalValue | ScriptObjectLocalValue | ScriptRegExpLocalValue | ScriptSetLocalValue;
 export type ScriptListLocalValue = ScriptLocalValue[];
 
 export interface ScriptArrayLocalValue {

--- a/tests/complex_types.test.ts
+++ b/tests/complex_types.test.ts
@@ -1,0 +1,53 @@
+import url from 'node:url'
+import path from 'node:path'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import cli from '../src/cli.js'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const complexTypesCDDL = path.join(__dirname, '__fixtures__', 'complex_types.cddl')
+
+vi.mock('../src/constants', () => ({
+    pkg: {
+        name: 'cddl2ts',
+        version: '0.0.0'
+    }
+}))
+
+describe('complex types (Map, Set, RegExp, Date...)', () => {
+    let exitOrig = process.exit
+    let logOrig = console.log
+    let errorOrig = console.error
+
+    beforeEach(() => {
+        process.exit = vi.fn() as any
+        console.log = vi.fn()
+        console.error = vi.fn()
+    })
+
+    afterEach(() => {
+        process.exit = exitOrig
+        console.log = logOrig
+        console.error = errorOrig
+    })
+
+    it('should include all types in the union', async () => {
+        await cli([complexTypesCDDL, '--unknown-as-any'])
+
+        expect(process.exit).not.toHaveBeenCalledWith(1)
+        expect(console.error).not.toHaveBeenCalled()
+        expect(console.log).toHaveBeenCalled()
+        const output = vi.mocked(console.log).mock.calls.flat().join('\n')
+
+        // Check if all types are present in the union or defined
+        expect(output).toContain('ArrayLocalValue')
+        expect(output).toContain('DateLocalValue')
+        expect(output).toContain('MapLocalValue')
+        expect(output).toContain('ObjectLocalValue')
+        expect(output).toContain('RegExpLocalValue')
+        expect(output).toContain('SetLocalValue')
+        
+        // Specific check for the buggy union generation where types were dropped
+        expect(output).toContain('export type LocalValue = ArrayLocalValue | DateLocalValue | MapLocalValue | ObjectLocalValue | RegExpLocalValue | SetLocalValue;')
+    })
+})


### PR DESCRIPTION
Add a unit test for a complex cddl choice, including `{}` for map & set.
The real fix was in cddl; this PR adds a unit test to keep generation for this case covered, so no release is needed.